### PR TITLE
Align Snap-to-Grid with Grid Lines and Set as Default

### DIFF
--- a/site/src/components/ShapeBuilder/index.js
+++ b/site/src/components/ShapeBuilder/index.js
@@ -47,7 +47,7 @@ const ShapeBuilder = () => {
     if (!poly) return;
 
     if (e.ctrlKey) {
-      poly.draw("param", "snapToGrid", 16);
+      poly.draw("param", "snapToGrid", 0.001);
     }
 
     if (e.ctrlKey && e.key === "Enter") {
@@ -66,7 +66,7 @@ const ShapeBuilder = () => {
   const handleKeyUp = (e) => {
     const poly = polyRef.current;
     if (!poly || e.ctrlKey) return;
-    poly.draw("param", "snapToGrid", 0.001);
+    poly.draw("param", "snapToGrid", 16);
   };
 
   const attachKeyListeners = () => {
@@ -105,7 +105,7 @@ const ShapeBuilder = () => {
         .draw()
         .attr({ stroke: "#00B39F", "stroke-width": 1, fill: "none" });
 
-      draw.draw("param", "snapToGrid", 0.001);
+      draw.draw("param", "snapToGrid", 16);
       draw.on("drawstart", attachKeyListeners);
       draw.on("drawdone", detachKeyListeners);
 

--- a/site/src/components/ShapeBuilder/index.js
+++ b/site/src/components/ShapeBuilder/index.js
@@ -47,7 +47,7 @@ const ShapeBuilder = () => {
     if (!poly) return;
 
     if (e.ctrlKey) {
-      poly.draw("param", "snapToGrid", 20);
+      poly.draw("param", "snapToGrid", 16);
     }
 
     if (e.ctrlKey && e.key === "Enter") {


### PR DESCRIPTION
**Notes for Reviewers**

- snap-to-grid feature wasn't aligning to the grid lines properly
- snap-to-grid is now the default drawing mode


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
