### PR TITLE
Fix: use ENTER to close a shape

### DIFF
--- a/site/src/components/ShapeBuilder/index.js
+++ b/site/src/components/ShapeBuilder/index.js
@@ -50,7 +50,7 @@ const ShapeBuilder = () => {
       poly.draw("param", "snapToGrid", 0.001);
     }
 
-    if (e.key === "Escape") {
+    if (e.key === "Enter") {
       poly.draw("done");
       poly.fill("#00B39F");
       showCytoArray();

--- a/site/src/components/ShapeBuilder/index.js
+++ b/site/src/components/ShapeBuilder/index.js
@@ -50,7 +50,7 @@ const ShapeBuilder = () => {
       poly.draw("param", "snapToGrid", 0.001);
     }
 
-    if (e.ctrlKey && e.key === "Enter") {
+    if (e.key === "Escape") {
       poly.draw("done");
       poly.fill("#00B39F");
       showCytoArray();

--- a/site/src/components/utils/instructionsModal.js
+++ b/site/src/components/utils/instructionsModal.js
@@ -3,7 +3,7 @@ import { Modal, ModalBody, Typography, List, ListItem, ListItemText, ModalFooter
 
 const instructionPoints = [
   {
-    primary: "Press ESC to close the shape",
+    primary: "Press ENTER to close the shape",
     secondary: "It won’t draw the last position of your cursor, don’t stress!"
   },
   {

--- a/site/src/components/utils/instructionsModal.js
+++ b/site/src/components/utils/instructionsModal.js
@@ -3,7 +3,7 @@ import { Modal, ModalBody, Typography, List, ListItem, ListItemText, ModalFooter
 
 const instructionPoints = [
   {
-    primary: "Press CTRL + Enter to close the shape",
+    primary: "Press ESC to close the shape",
     secondary: "It won’t draw the last position of your cursor, don’t stress!"
   },
   {


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #37 

To close a shape, the user can now use just the `Enter` key instead of using `CTRL+Enter`

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
