### PR TITLE
Fix: Add the consistent box border color for outputbox while selecting

### DIFF
--- a/site/src/components/ShapeBuilder/shapeBuilder.styles.js
+++ b/site/src/components/ShapeBuilder/shapeBuilder.styles.js
@@ -113,7 +113,7 @@ export const OutputBox = styled.div`
     font-size: 0.95rem;
     &:focus {
       outline:none;
-      border: 1px solid ${({ theme }) => theme.primary || "#009684"};
+      border: 1px solid ${({ theme }) => theme.primary};
     }
   }
 
@@ -134,11 +134,11 @@ export const CopyButton = styled.button`
   display: flex;
   align-items: center;
   font-size: 12px;
-  color: ${({ theme }) => theme.primary || "#009684"};
+  color: ${({ theme }) => theme.primary};
 
   svg {
-    color: ${({ theme }) => theme.primary || "#009684"};
-    fill: ${({ theme }) => theme.primary || "#009684"};
+    color: ${({ theme }) => theme.primary};
+    fill: ${({ theme }) => theme.primary};
   }
 `;
 


### PR DESCRIPTION
**Notes for Reviewers**
Fix the border color of OutputBox by adding the consistent color of the page while selecting it.
Before
<img width="1366" height="768" alt="Screenshot (281)" src="https://github.com/user-attachments/assets/6aac569c-a3eb-49c1-93eb-01a08d520350" />
After
<img width="1366" height="768" alt="Screenshot (280)" src="https://github.com/user-attachments/assets/af2bcd73-efa2-428c-ba85-18d9c4ff4712" />

- This PR fixes #77 

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
