### PR TITLE
feat: replace instruction modal with persistent keyboard shortcuts

### DIFF
--- a/site/src/pages/index.js
+++ b/site/src/pages/index.js
@@ -50,7 +50,7 @@ const SectionLabel = styled.h3`
   font-size: 2rem;
   font-weight: 500;
   color: ${({ theme }) => (theme.mode === "light" ? "#111" : "#fff")}; /* Matched header contrast */
-  margin: 0 0 12px 0;
+  margin: 0 0 8px 0;
   text-align: center;
 `;
 


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #73

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

## Description
This PR addresses the usability issue where the "Show Instructions" modal would block the drawing grid, preventing users from reading instructions and drawing simultaneously.

**Changes:**
1. Removed the `Show Instructions` button and the blocking `InstructionsModal` component.
2. Implemented a persistent, responsive "Keyboard Shortcut" bar directly on the main page.
3. Utilized a "Key" style (similar to VS Code/GitHub UI) to make the shortcuts distinct and easy to scan.
4. Refactored `src/pages/index.js` to accommodate the new layout.

This allows users to reference the controls (Enter, Ctrl+Z, etc.) without interrupting their workflow.

## Screenshots

**Before**
<img width="2048" height="1260" alt="image" src="https://github.com/user-attachments/assets/7c0b7788-c553-4e54-a3be-86a0b31c30e7" />

**After**
<img width="3690" height="2272" alt="image" src="https://github.com/user-attachments/assets/dc8b8465-3595-4fb0-8339-bca019a90f0d" />
