### PR TITLE
feat: add live mouse coordinate display to shape builder canvas

### DIFF
--- a/site/src/components/ShapeBuilder/index.js
+++ b/site/src/components/ShapeBuilder/index.js
@@ -75,26 +75,29 @@ const ShapeBuilder = () => {
   };
   
   const handleMouseMove = (e) => {
-  const svg = boardRef.current;
-  if (!svg) return;
+    const svg = boardRef.current;
+    if (!svg) return;
 
-  const rect = svg.getBoundingClientRect();
-  const x = e.clientX - rect.left;
-  const y = e.clientY - rect.top;
-  const centerX = rect.width / 2;
-  const centerY = rect.height / 2;
-  const normalizedX = (x - centerX) / centerX;
-  const normalizedY = (y - centerY) / centerY;
+    const rect = svg.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+    const centerX = rect.width / 2;
+    const centerY = rect.height / 2;
+    const normalizedX = (x - centerX) / centerX;
+    const normalizedY = (y - centerY) / centerY;
 
-  setMouseCoords({
-    x: Math.round(x),
-    y: Math.round(y),
-    normalized: {
-      x: parseFloat(normalizedX.toFixed(3)),
-      y: parseFloat(normalizedY.toFixed(3))
-    }
-  });
-};
+    setMouseCoords({
+      x: Math.round(x),
+      y: Math.round(y),
+      normalized: {
+        x: parseFloat(normalizedX.toFixed(3)),
+        y: parseFloat(normalizedY.toFixed(3))
+      },
+
+      screenX: e.clientX,
+      screenY: e.clientY
+    });
+  };
 
   const handleMouseEnter = () => {
     setIsMouseInCanvas(true);
@@ -222,30 +225,16 @@ const ShapeBuilder = () => {
           <rect className="grid" width="100%" height="100%" fill="url(#grid)" />
         </StyledSVG>
 
-        {isMouseInCanvas && (
-          <CoordinateDisplay>
-            <div className="coordinate-label">Mouse Position</div>
-            <div className="coordinate-values">
-              <div className="coordinate-item">
-                <span className="axis-label">X:</span>
-                <span className="axis-value">{mouseCoords.normalized.x}</span>
-              </div>
-              <div className="coordinate-item">
-                <span className="axis-label">Y:</span>
-                <span className="axis-value">{mouseCoords.normalized.y}</span>
-              </div>
-            </div>
-            <div style={{ 
-              marginTop: "8px", 
-              paddingTop: "8px", 
-              borderTop: "1px solid rgba(0, 179, 159, 0.3)",
-              fontSize: "10px",
-              color: "#666"
-            }}>
-              Pixel: ({mouseCoords.x}, {mouseCoords.y})
-            </div>
-          </CoordinateDisplay>
-        )}
+       {isMouseInCanvas && (
+        <CoordinateDisplay
+          style={{
+            left: `${mouseCoords.x + 15}px`,  
+            top: `${mouseCoords.y + 15}px`   
+          }}
+        >
+          X: {mouseCoords.normalized.x}, Y: {mouseCoords.normalized.y}
+        </CoordinateDisplay>
+      )}
 
         {error && (
           <div style={{

--- a/site/src/components/ShapeBuilder/index.js
+++ b/site/src/components/ShapeBuilder/index.js
@@ -17,6 +17,7 @@ const ShapeBuilder = () => {
 
   const [mouseCoords, setMouseCoords] = useState({ x: 0, y: 0, normalized: { x: 0, y: 0 } });
   const [isMouseInCanvas, setIsMouseInCanvas] = useState(false);
+  const [showCoordinates, setShowCoordinates] = useState(true);
 
   const handleCopyToClipboard = async () => {
     if (!result.trim()) return;
@@ -105,6 +106,10 @@ const ShapeBuilder = () => {
 
   const handleMouseLeave = () => {
     setIsMouseInCanvas(false);
+  };
+
+  const toggleCoordinates = () => {
+  setShowCoordinates(prev => !prev);
   };
 
   const handleKeyDown = (e) => {
@@ -225,7 +230,7 @@ const ShapeBuilder = () => {
           <rect className="grid" width="100%" height="100%" fill="url(#grid)" />
         </StyledSVG>
 
-       {isMouseInCanvas && (
+       {isMouseInCanvas && showCoordinates && (
         <CoordinateDisplay
           style={{
             left: `${mouseCoords.x + 15}px`,  
@@ -256,6 +261,7 @@ const ShapeBuilder = () => {
         <Button variant="contained" onClick={clearShape}>Clear</Button>
         <Button variant="contained" onClick={closeShape}>Close Shape</Button>
         <Button variant="contained" onClick={handleMaximize}>Maximize</Button>
+        <Button variant="contained" onClick={toggleCoordinates}>{showCoordinates ? "Hide Coordinates" : "Show Coordinates"}</Button>
       </Box>
 
       <OutputBox>

--- a/site/src/components/ShapeBuilder/index.js
+++ b/site/src/components/ShapeBuilder/index.js
@@ -1,6 +1,6 @@
 // /* global window */
 import React, { useEffect, useRef, useState } from "react";
-import { Wrapper, CanvasContainer, OutputBox, StyledSVG, CopyButton } from "./shapeBuilder.styles";
+import { Wrapper, CanvasContainer, OutputBox, StyledSVG, CopyButton, CoordinateDisplay } from "./shapeBuilder.styles";
 import { Button, Typography, Box, CopyIcon } from "@sistent/sistent";
 import { SVG, extend as SVGextend } from "@svgdotjs/svg.js";
 import draw from "@svgdotjs/svg.draw.js";
@@ -14,6 +14,9 @@ const ShapeBuilder = () => {
   const [result, setResult] = useState("");
   const [error, setError] = useState(null);
   const [showCopied, setShowCopied] = useState(false);
+
+  const [mouseCoords, setMouseCoords] = useState({ x: 0, y: 0, normalized: { x: 0, y: 0 } });
+  const [isMouseInCanvas, setIsMouseInCanvas] = useState(false);
 
   const handleCopyToClipboard = async () => {
     if (!result.trim()) return;
@@ -69,6 +72,36 @@ const ShapeBuilder = () => {
     poly.size(width > height ? 520 : undefined, height >= width ? 520 : undefined);
     poly.move(0, 0);
     showCytoArray();
+  };
+  
+  const handleMouseMove = (e) => {
+  const svg = boardRef.current;
+  if (!svg) return;
+
+  const rect = svg.getBoundingClientRect();
+  const x = e.clientX - rect.left;
+  const y = e.clientY - rect.top;
+  const centerX = rect.width / 2;
+  const centerY = rect.height / 2;
+  const normalizedX = (x - centerX) / centerX;
+  const normalizedY = (y - centerY) / centerY;
+
+  setMouseCoords({
+    x: Math.round(x),
+    y: Math.round(y),
+    normalized: {
+      x: parseFloat(normalizedX.toFixed(3)),
+      y: parseFloat(normalizedY.toFixed(3))
+    }
+  });
+};
+
+  const handleMouseEnter = () => {
+    setIsMouseInCanvas(true);
+  };
+
+  const handleMouseLeave = () => {
+    setIsMouseInCanvas(false);
   };
 
   const handleKeyDown = (e) => {
@@ -177,6 +210,9 @@ const ShapeBuilder = () => {
           width="100%"
           height="100%"
           onDoubleClick={closeShape}
+          onMouseMove={handleMouseMove}
+          onMouseEnter={handleMouseEnter}
+          onMouseLeave={handleMouseLeave}
         >
           <defs>
             <pattern id="grid" width="16" height="16" patternUnits="userSpaceOnUse">
@@ -185,6 +221,32 @@ const ShapeBuilder = () => {
           </defs>
           <rect className="grid" width="100%" height="100%" fill="url(#grid)" />
         </StyledSVG>
+
+        {isMouseInCanvas && (
+          <CoordinateDisplay>
+            <div className="coordinate-label">Mouse Position</div>
+            <div className="coordinate-values">
+              <div className="coordinate-item">
+                <span className="axis-label">X:</span>
+                <span className="axis-value">{mouseCoords.normalized.x}</span>
+              </div>
+              <div className="coordinate-item">
+                <span className="axis-label">Y:</span>
+                <span className="axis-value">{mouseCoords.normalized.y}</span>
+              </div>
+            </div>
+            <div style={{ 
+              marginTop: "8px", 
+              paddingTop: "8px", 
+              borderTop: "1px solid rgba(0, 179, 159, 0.3)",
+              fontSize: "10px",
+              color: "#666"
+            }}>
+              Pixel: ({mouseCoords.x}, {mouseCoords.y})
+            </div>
+          </CoordinateDisplay>
+        )}
+
         {error && (
           <div style={{
             position: "absolute",

--- a/site/src/components/ShapeBuilder/index.js
+++ b/site/src/components/ShapeBuilder/index.js
@@ -1,6 +1,6 @@
 // /* global window */
 import React, { useEffect, useRef, useState } from "react";
-import { Wrapper, CanvasContainer, OutputBox, StyledSVG, CopyButton } from "./shapeBuilder.styles";
+import { Wrapper, CanvasContainer, OutputBox, StyledSVG, CopyButton, CoordinateDisplay } from "./shapeBuilder.styles";
 import { Button, Typography, Box, CopyIcon, Select, MenuItem, Slider, FormControl } from "@sistent/sistent";
 import { SVG, extend as SVGextend } from "@svgdotjs/svg.js";
 import draw from "@svgdotjs/svg.draw.js";
@@ -22,6 +22,9 @@ const ShapeBuilder = () => {
   const [showCopied, setShowCopied] = useState(false);
   const [scale, setScale] = useState(1);
   const [currentPreset, setCurrentPreset] = useState(1);
+
+  const [mouseCoords, setMouseCoords] = useState({ x: 0, y: 0, normalized: { x: 0, y: 0 } });
+  const [isMouseInCanvas, setIsMouseInCanvas] = useState(false);
 
   const handleCopyToClipboard = async () => {
     if (!result.trim()) return;
@@ -88,6 +91,36 @@ const ShapeBuilder = () => {
 
     poly.plot(scaledPoints);
     showCytoArray();
+  };
+  
+  const handleMouseMove = (e) => {
+  const svg = boardRef.current;
+  if (!svg) return;
+
+  const rect = svg.getBoundingClientRect();
+  const x = e.clientX - rect.left;
+  const y = e.clientY - rect.top;
+  const centerX = rect.width / 2;
+  const centerY = rect.height / 2;
+  const normalizedX = (x - centerX) / centerX;
+  const normalizedY = (y - centerY) / centerY;
+
+  setMouseCoords({
+    x: Math.round(x),
+    y: Math.round(y),
+    normalized: {
+      x: parseFloat(normalizedX.toFixed(3)),
+      y: parseFloat(normalizedY.toFixed(3))
+    }
+  });
+};
+
+  const handleMouseEnter = () => {
+    setIsMouseInCanvas(true);
+  };
+
+  const handleMouseLeave = () => {
+    setIsMouseInCanvas(false);
   };
 
   const handleScaleChange = (newScale) => {
@@ -225,6 +258,9 @@ const ShapeBuilder = () => {
           width="100%"
           height="100%"
           onDoubleClick={closeShape}
+          onMouseMove={handleMouseMove}
+          onMouseEnter={handleMouseEnter}
+          onMouseLeave={handleMouseLeave}
         >
           <defs>
             <pattern id="grid" width="16" height="16" patternUnits="userSpaceOnUse">
@@ -233,6 +269,32 @@ const ShapeBuilder = () => {
           </defs>
           <rect className="grid" width="100%" height="100%" fill="url(#grid)" />
         </StyledSVG>
+
+        {isMouseInCanvas && (
+          <CoordinateDisplay>
+            <div className="coordinate-label">Mouse Position</div>
+            <div className="coordinate-values">
+              <div className="coordinate-item">
+                <span className="axis-label">X:</span>
+                <span className="axis-value">{mouseCoords.normalized.x}</span>
+              </div>
+              <div className="coordinate-item">
+                <span className="axis-label">Y:</span>
+                <span className="axis-value">{mouseCoords.normalized.y}</span>
+              </div>
+            </div>
+            <div style={{ 
+              marginTop: "8px", 
+              paddingTop: "8px", 
+              borderTop: "1px solid rgba(0, 179, 159, 0.3)",
+              fontSize: "10px",
+              color: "#666"
+            }}>
+              Pixel: ({mouseCoords.x}, {mouseCoords.y})
+            </div>
+          </CoordinateDisplay>
+        )}
+
         {error && (
           <div style={{
             position: "absolute",

--- a/site/src/components/ShapeBuilder/index.js
+++ b/site/src/components/ShapeBuilder/index.js
@@ -12,6 +12,43 @@ const MIN_SCALE = 0.1;
 const MAX_SCALE = 3;
 const MIN_POLYGON_POINTS = 3;
 
+// Gap in px kept between the pointer and the coordinate readout.
+const READOUT_GAP = 16;
+// Decimal places shown in the readout.
+const READOUT_PRECISION = 3;
+
+/*
+ * Maps a point in canvas pixels onto -1..1 relative to the canvas centre.
+ * Note this is measured off the live element, whereas `showCytoArray` still
+ * normalizes against a hardcoded 260px half-extent; the two agree only while
+ * the canvas is 520px square, which it is not at most viewport widths. That
+ * hardcoded divisor predates this feature and is left for a separate change so
+ * the polygon output contract is not altered here.
+ */
+const normalizeToCanvas = (x, y, rect) => [
+  (x - rect.width / 2) / (rect.width / 2),
+  (y - rect.height / 2) / (rect.height / 2)
+];
+
+/*
+ * Anchors the readout to whichever pair of container edges keeps it on screen.
+ * Anchoring the far side with `right`/`bottom` means the readout never has to be
+ * measured to know it will not be clipped near the canvas edge.
+ */
+const buildReadoutAnchor = (x, y, rect) => {
+  const anchor = x > rect.width / 2
+    ? { right: `${Math.round(rect.width - x + READOUT_GAP)}px` }
+    : { left: `${Math.round(x + READOUT_GAP)}px` };
+
+  if (y > rect.height / 2) {
+    anchor.bottom = `${Math.round(rect.height - y + READOUT_GAP)}px`;
+  } else {
+    anchor.top = `${Math.round(y + READOUT_GAP)}px`;
+  }
+
+  return anchor;
+};
+
 const ShapeBuilder = () => {
   const boardRef = useRef(null);
   const polyRef = useRef(null);
@@ -23,9 +60,12 @@ const ShapeBuilder = () => {
   const [scale, setScale] = useState(1);
   const [currentPreset, setCurrentPreset] = useState(1);
 
-  const [mouseCoords, setMouseCoords] = useState({ x: 0, y: 0, normalized: { x: 0, y: 0 } });
-  const [isMouseInCanvas, setIsMouseInCanvas] = useState(false);
+  // `null` whenever the pointer is off the canvas, so position and visibility
+  // can never disagree.
+  const [readout, setReadout] = useState(null);
   const [showCoordinates, setShowCoordinates] = useState(true);
+  const readoutFrameRef = useRef(0);
+  const pendingReadoutRef = useRef(null);
 
   const handleCopyToClipboard = async () => {
     if (!result.trim()) return;
@@ -93,38 +133,51 @@ const ShapeBuilder = () => {
     poly.plot(scaledPoints);
     showCytoArray();
   };
-  
-  const handleMouseMove = (e) => {
-    const svg = boardRef.current;
-    if (!svg) return;
 
-    const rect = svg.getBoundingClientRect();
-    const x = e.clientX - rect.left;
-    const y = e.clientY - rect.top;
-    const centerX = rect.width / 2;
-    const centerY = rect.height / 2;
-    const normalizedX = (x - centerX) / centerX;
-    const normalizedY = (y - centerY) / centerY;
+  const cancelReadoutFrame = () => {
+    if (readoutFrameRef.current) {
+      window.cancelAnimationFrame(readoutFrameRef.current);
+      readoutFrameRef.current = 0;
+    }
+    pendingReadoutRef.current = null;
+  };
 
-    setMouseCoords({
-      x: Math.round(x),
-      y: Math.round(y),
-      normalized: {
-        x: parseFloat(normalizedX.toFixed(3)),
-        y: parseFloat(normalizedY.toFixed(3))
-      },
+  // Pointer events fire faster than the browser paints, so coalesce them onto a
+  // single animation frame rather than re-rendering once per event.
+  const scheduleReadout = (next) => {
+    pendingReadoutRef.current = next;
+    if (readoutFrameRef.current) return;
 
-      screenX: e.clientX,
-      screenY: e.clientY
+    readoutFrameRef.current = window.requestAnimationFrame(() => {
+      readoutFrameRef.current = 0;
+      setReadout(pendingReadoutRef.current);
     });
   };
 
-  const handleMouseEnter = () => {
-    setIsMouseInCanvas(true);
+  // Pointer events cover mouse, pen and touch with one standard API supported by
+  // every current browser; `currentTarget` is always the canvas the handler is
+  // bound to, even when the event bubbles up from a drawn shape.
+  const handlePointerMove = (e) => {
+    const rect = e.currentTarget.getBoundingClientRect();
+    if (!rect.width || !rect.height) return;
+
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+    const [normalizedX, normalizedY] = normalizeToCanvas(x, y, rect);
+
+    scheduleReadout({
+      anchor: buildReadoutAnchor(x, y, rect),
+      x: normalizedX.toFixed(READOUT_PRECISION),
+      y: normalizedY.toFixed(READOUT_PRECISION)
+    });
   };
 
-  const handleMouseLeave = () => {
-    setIsMouseInCanvas(false);
+  // Covers pointerleave and pointercancel: a touch or pen stream that is taken
+  // over by the browser never emits a leave, and would otherwise strand the
+  // readout on screen.
+  const hideReadout = () => {
+    cancelReadoutFrame();
+    setReadout(null);
   };
 
   const handleScaleChange = (newScale) => {
@@ -149,7 +202,7 @@ const ShapeBuilder = () => {
   };
 
   const toggleCoordinates = () => {
-    setShowCoordinates(prev => !prev);
+    setShowCoordinates((prev) => !prev);
   };
 
   const handleKeyDown = (e) => {
@@ -249,6 +302,7 @@ const ShapeBuilder = () => {
   useEffect(() => {
     initializeDrawing();
     return () => {
+      cancelReadoutFrame();
       detachKeyListeners();
       if (polyRef.current) {
         polyRef.current.draw("cancel");
@@ -266,9 +320,10 @@ const ShapeBuilder = () => {
           width="100%"
           height="100%"
           onDoubleClick={closeShape}
-          onMouseMove={handleMouseMove}
-          onMouseEnter={handleMouseEnter}
-          onMouseLeave={handleMouseLeave}
+          onPointerMove={handlePointerMove}
+          onPointerEnter={handlePointerMove}
+          onPointerLeave={hideReadout}
+          onPointerCancel={hideReadout}
         >
           <defs>
             <pattern id="grid" width="16" height="16" patternUnits="userSpaceOnUse">
@@ -278,16 +333,12 @@ const ShapeBuilder = () => {
           <rect className="grid" width="100%" height="100%" fill="url(#grid)" />
         </StyledSVG>
 
-       {isMouseInCanvas && showCoordinates && (
-        <CoordinateDisplay
-          style={{
-            left: `${mouseCoords.x + 15}px`,  
-            top: `${mouseCoords.y + 15}px`   
-          }}
-        >
-          X: {mouseCoords.normalized.x}, Y: {mouseCoords.normalized.y}
-        </CoordinateDisplay>
-      )}
+        {showCoordinates && readout && (
+          /* Decorative, pointer-only overlay: keep it out of the a11y tree. */
+          <CoordinateDisplay aria-hidden="true" style={readout.anchor}>
+            X: {readout.x}, Y: {readout.y}
+          </CoordinateDisplay>
+        )}
 
         {error && (
           <div style={{
@@ -308,7 +359,13 @@ const ShapeBuilder = () => {
       <Box sx={{ display: "flex", justifyContent: "center", alignItems: "center", gap: 2, mt: 3, mb: 3, flexWrap: "wrap" }}>
         <Button variant="contained" onClick={clearShape}>Clear</Button>
         <Button variant="contained" onClick={closeShape}>Close Shape</Button>
-        <Button variant="contained" onClick={toggleCoordinates}>{showCoordinates ? "Hide Coordinates" : "Show Coordinates"}</Button>
+        <Button
+          variant="contained"
+          onClick={toggleCoordinates}
+          aria-pressed={showCoordinates}
+        >
+          {showCoordinates ? "Hide Coordinates" : "Show Coordinates"}
+        </Button>
 
         <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, ml: 2 }}>
           <FormControl size="small" sx={{ minWidth: 80 }}>

--- a/site/src/components/ShapeBuilder/index.js
+++ b/site/src/components/ShapeBuilder/index.js
@@ -25,6 +25,7 @@ const ShapeBuilder = () => {
 
   const [mouseCoords, setMouseCoords] = useState({ x: 0, y: 0, normalized: { x: 0, y: 0 } });
   const [isMouseInCanvas, setIsMouseInCanvas] = useState(false);
+  const [showCoordinates, setShowCoordinates] = useState(true);
 
   const handleCopyToClipboard = async () => {
     if (!result.trim()) return;
@@ -145,6 +146,10 @@ const ShapeBuilder = () => {
 
   const handleSliderChange = (event, newValue) => {
     handleScaleChange(newValue);
+  };
+
+  const toggleCoordinates = () => {
+    setShowCoordinates(prev => !prev);
   };
 
   const handleKeyDown = (e) => {
@@ -273,7 +278,7 @@ const ShapeBuilder = () => {
           <rect className="grid" width="100%" height="100%" fill="url(#grid)" />
         </StyledSVG>
 
-       {isMouseInCanvas && (
+       {isMouseInCanvas && showCoordinates && (
         <CoordinateDisplay
           style={{
             left: `${mouseCoords.x + 15}px`,  
@@ -303,6 +308,7 @@ const ShapeBuilder = () => {
       <Box sx={{ display: "flex", justifyContent: "center", alignItems: "center", gap: 2, mt: 3, mb: 3, flexWrap: "wrap" }}>
         <Button variant="contained" onClick={clearShape}>Clear</Button>
         <Button variant="contained" onClick={closeShape}>Close Shape</Button>
+        <Button variant="contained" onClick={toggleCoordinates}>{showCoordinates ? "Hide Coordinates" : "Show Coordinates"}</Button>
 
         <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, ml: 2 }}>
           <FormControl size="small" sx={{ minWidth: 80 }}>

--- a/site/src/components/ShapeBuilder/index.js
+++ b/site/src/components/ShapeBuilder/index.js
@@ -94,26 +94,29 @@ const ShapeBuilder = () => {
   };
   
   const handleMouseMove = (e) => {
-  const svg = boardRef.current;
-  if (!svg) return;
+    const svg = boardRef.current;
+    if (!svg) return;
 
-  const rect = svg.getBoundingClientRect();
-  const x = e.clientX - rect.left;
-  const y = e.clientY - rect.top;
-  const centerX = rect.width / 2;
-  const centerY = rect.height / 2;
-  const normalizedX = (x - centerX) / centerX;
-  const normalizedY = (y - centerY) / centerY;
+    const rect = svg.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+    const centerX = rect.width / 2;
+    const centerY = rect.height / 2;
+    const normalizedX = (x - centerX) / centerX;
+    const normalizedY = (y - centerY) / centerY;
 
-  setMouseCoords({
-    x: Math.round(x),
-    y: Math.round(y),
-    normalized: {
-      x: parseFloat(normalizedX.toFixed(3)),
-      y: parseFloat(normalizedY.toFixed(3))
-    }
-  });
-};
+    setMouseCoords({
+      x: Math.round(x),
+      y: Math.round(y),
+      normalized: {
+        x: parseFloat(normalizedX.toFixed(3)),
+        y: parseFloat(normalizedY.toFixed(3))
+      },
+
+      screenX: e.clientX,
+      screenY: e.clientY
+    });
+  };
 
   const handleMouseEnter = () => {
     setIsMouseInCanvas(true);
@@ -270,30 +273,16 @@ const ShapeBuilder = () => {
           <rect className="grid" width="100%" height="100%" fill="url(#grid)" />
         </StyledSVG>
 
-        {isMouseInCanvas && (
-          <CoordinateDisplay>
-            <div className="coordinate-label">Mouse Position</div>
-            <div className="coordinate-values">
-              <div className="coordinate-item">
-                <span className="axis-label">X:</span>
-                <span className="axis-value">{mouseCoords.normalized.x}</span>
-              </div>
-              <div className="coordinate-item">
-                <span className="axis-label">Y:</span>
-                <span className="axis-value">{mouseCoords.normalized.y}</span>
-              </div>
-            </div>
-            <div style={{ 
-              marginTop: "8px", 
-              paddingTop: "8px", 
-              borderTop: "1px solid rgba(0, 179, 159, 0.3)",
-              fontSize: "10px",
-              color: "#666"
-            }}>
-              Pixel: ({mouseCoords.x}, {mouseCoords.y})
-            </div>
-          </CoordinateDisplay>
-        )}
+       {isMouseInCanvas && (
+        <CoordinateDisplay
+          style={{
+            left: `${mouseCoords.x + 15}px`,  
+            top: `${mouseCoords.y + 15}px`   
+          }}
+        >
+          X: {mouseCoords.normalized.x}, Y: {mouseCoords.normalized.y}
+        </CoordinateDisplay>
+      )}
 
         {error && (
           <div style={{

--- a/site/src/components/ShapeBuilder/shapeBuilder.styles.js
+++ b/site/src/components/ShapeBuilder/shapeBuilder.styles.js
@@ -153,7 +153,6 @@ export const CoordinateDisplay = styled.div`
   z-index: 1000;
   user-select: none;
   white-space: nowrap;
-  transition: left 0.05s ease-out, top 0.05s ease-out;
 `;
 
 // export const Wrapper = styled.div`

--- a/site/src/components/ShapeBuilder/shapeBuilder.styles.js
+++ b/site/src/components/ShapeBuilder/shapeBuilder.styles.js
@@ -140,51 +140,20 @@ export const CopyButton = styled.button`
 
 export const CoordinateDisplay = styled.div`
   position: absolute;
-  top: 10px;
-  right: 10px;
+  pointer-events: none;
   background-color: ${({ theme }) => theme?.mode === "light" ? "rgba(255, 255, 255, 0.95)" : "rgba(43, 43, 43, 0.95)"};
   border: 2px solid #00B39F;
-  border-radius: 8px;
-  padding: 12px 16px;
+  border-radius: 6px;
+  padding: 6px 10px;
   font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
-  font-size: 14px;
+  font-size: 12px;
   font-weight: 600;
   color: ${({ theme }) => theme?.mode === "light" ? "#111" : "#fff"};
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-  z-index: 10;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  z-index: 1000;
   user-select: none;
-  min-width: 150px;
-
-  .coordinate-label {
-    color: #00B39F;
-    font-size: 12px;
-    margin-bottom: 4px;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-  }
-
-  .coordinate-values {
-    display: flex;
-    gap: 16px;
-    margin-top: 8px;
-  }
-
-  .coordinate-item {
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
-  }
-
-  .axis-label {
-    font-size: 11px;
-    color: ${({ theme }) => theme?.mode === "light" ? "#666" : "#aaa"};
-  }
-
-  .axis-value {
-    font-size: 16px;
-    color: ${({ theme }) => theme?.mode === "light" ? "#111" : "#fff"};
-    font-weight: 700;
-  }
+  white-space: nowrap;
+  transition: left 0.05s ease-out, top 0.05s ease-out;
 `;
 
 // export const Wrapper = styled.div`

--- a/site/src/components/ShapeBuilder/shapeBuilder.styles.js
+++ b/site/src/components/ShapeBuilder/shapeBuilder.styles.js
@@ -138,6 +138,55 @@ export const CopyButton = styled.button`
   }
 `;
 
+export const CoordinateDisplay = styled.div`
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  background-color: ${({ theme }) => theme?.mode === "light" ? "rgba(255, 255, 255, 0.95)" : "rgba(43, 43, 43, 0.95)"};
+  border: 2px solid #00B39F;
+  border-radius: 8px;
+  padding: 12px 16px;
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  font-size: 14px;
+  font-weight: 600;
+  color: ${({ theme }) => theme?.mode === "light" ? "#111" : "#fff"};
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  z-index: 10;
+  user-select: none;
+  min-width: 150px;
+
+  .coordinate-label {
+    color: #00B39F;
+    font-size: 12px;
+    margin-bottom: 4px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+
+  .coordinate-values {
+    display: flex;
+    gap: 16px;
+    margin-top: 8px;
+  }
+
+  .coordinate-item {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .axis-label {
+    font-size: 11px;
+    color: ${({ theme }) => theme?.mode === "light" ? "#666" : "#aaa"};
+  }
+
+  .axis-value {
+    font-size: 16px;
+    color: ${({ theme }) => theme?.mode === "light" ? "#111" : "#fff"};
+    font-weight: 700;
+  }
+`;
+
 // export const Wrapper = styled.div`
 //   padding: 2rem;
 //   background-color: ${({ theme }) => theme.palette.background.default};

--- a/site/src/components/ShapeBuilder/shapeBuilder.styles.js
+++ b/site/src/components/ShapeBuilder/shapeBuilder.styles.js
@@ -1,5 +1,22 @@
 import styled from "styled-components";
-// import styled from "@sistent/sistent";
+import { createTheme, darkModePalette, lightModePalette, typography } from "@sistent/sistent";
+
+/*
+ * Sistent design tokens.
+ *
+ * styled-components resolves `theme` from the styled-components ThemeProvider in
+ * src/pages/index.js, which supplies this site's local theme - Sistent's MUI
+ * theme lives in a separate (emotion) context and is not reachable from here.
+ * So Sistent's tokens are read straight from the library's exported token sets
+ * and selected with the same `theme.mode` flag the rest of the site keys off.
+ */
+const sistentBase = createTheme();
+
+const sistentPalette = ({ theme }) =>
+  (theme?.mode === "light" ? lightModePalette : darkModePalette);
+
+const sistentTypography = ({ theme }) =>
+  typography(theme?.mode === "light" ? "light" : "dark");
 
 // NOTE: background colors are hardcoded-temporarily for testing
 
@@ -140,19 +157,34 @@ export const CopyButton = styled.button`
 
 export const CoordinateDisplay = styled.div`
   position: absolute;
+  /* Never intercept pointer events - the readout sits over the drawing surface. */
   pointer-events: none;
-  background-color: ${({ theme }) => theme?.mode === "light" ? "rgba(255, 255, 255, 0.95)" : "rgba(43, 43, 43, 0.95)"};
-  border: 2px solid #00B39F;
-  border-radius: 6px;
-  padding: 6px 10px;
-  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
-  font-size: 12px;
-  font-weight: 600;
-  color: ${({ theme }) => theme?.mode === "light" ? "#111" : "#fff"};
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
-  z-index: 1000;
-  user-select: none;
+  z-index: ${sistentBase.zIndex.tooltip};
+
+  padding: ${sistentBase.spacing(0.75)} ${sistentBase.spacing(1.25)};
+  border: 1px solid ${(props) => sistentPalette(props).border.brand};
+  border-radius: ${sistentBase.shape.borderRadius}px;
+  background-color: ${(props) => sistentPalette(props).background.elevatedComponents};
+  color: ${(props) => sistentPalette(props).text.default};
+  box-shadow: ${sistentBase.shadows[2]};
+
+  /*
+   * Brand font only. "Qanelas Soft" is the family name declared in
+   * src/fonts.css and used by src/styles/styles.js; Sistent's own token spells
+   * it "Qanelas Soft Regular", which this site does not load, so the family is
+   * named here and only the size/weight/rhythm come from the Sistent scale.
+   */
+  font-family: "Qanelas Soft";
+  font-size: ${(props) => sistentTypography(props).textL1Bold.fontSize};
+  font-weight: ${(props) => sistentTypography(props).textL1Bold.fontWeight};
+  line-height: ${(props) => sistentTypography(props).textL1Bold.lineHeight};
+  /* Keeps the readout from twitching as digits change width. */
+  font-variant-numeric: tabular-nums;
+
   white-space: nowrap;
+  /* WebKit still needs the prefix for user-select. */
+  -webkit-user-select: none;
+  user-select: none;
 `;
 
 // export const Wrapper = styled.div`


### PR DESCRIPTION
## Description

This PR adds a live mouse coordinate display to the shape builder canvas that shows real-time X/Y coordinates as users move their mouse over the grid. This enhancement improves the user experience by providing precise position feedback during shape creation.

## Related Issue

Fixes #95

## Changes Made

-  Added real-time coordinate tracking on mouse movement
-  Display shows coordinates (-1 to 1 range) matching the polygon output format
-  Pixel coordinates shown for reference
-  Coordinate display only visible when mouse hovers over canvas (non-intrusive)
-  Works in both light & dark mode
-  Kept it in the top-right corner
-  Smooth show & hide transitions on mouse enter & leave
-  Dynamic center calculation based on canvas size

**New Component:**
 `CoordinateDisplay`

**Coordinate Normalization:**
- Dynamic center calculation: `centerX = rect.width / 2`, `centerY = rect.height / 2`
- Normalization formula: `(x - centerX) / centerX` for -1 to 1 range
- 3 decimal precision for accuracy

## Current Behavior vs New Behavior

**Before:** 
- Users had no way to see exact pointer positions while creating shapes
- Difficult to place points precisely

https://github.com/user-attachments/assets/8f41c42d-fa35-416a-9f65-27a96e3edc3f




**After:** 
- Users can see precise coordinates (-1 to 1)
- Pixel coordinates provided for reference

https://github.com/user-attachments/assets/a72162f7-f07e-4dd1-853c-50e984350c58


## Testing Performed
Isnt breaking any existing functionality as per my knowledge. Pls let me know if something breaks.


## Files Modified

- `site/src/components/ShapeBuilder/index.js` - Added coordinate tracking logic and display component
- `site/src/components/ShapeBuilder/shapeBuilder.styles.js` - Added `CoordinateDisplay` styled component

## Notes for Reviewers

- This PR fixes #95
- Theme styling follows existing patterns in the codebase
- Display is conditionally rendered (only visible on hover) to avoid clutter

## **[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

---

**Checklist:**
- [x] Code follows project style guidelines
- [x] Changes tested locally in both themes
- [x] No breaking changes
- [x] All existing features work correctly
- [x] Linting passes without errors
- [x] Commit message follows conventional commits format
- [x] PR description is clear and complete with screenshots




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional coordinate readout to the shape builder.
  - Displays normalized canvas coordinates as the pointer moves.
  - Positions the readout near the pointer while keeping it within canvas bounds.
  - Added controls to show or hide the coordinate display.
  - Replaced maximize with polygon scaling controls, including presets and a slider.
  - Preserves original polygon points while scaling and supports closing shapes with Escape or Enter.
- **Bug Fixes**
  - Improved polygon validation before filling and cleaned up pointer interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->