### PR TITLE
Fix polygon creation: require minimum 3 points

### DIFF
--- a/site/src/components/ShapeBuilder/index.js
+++ b/site/src/components/ShapeBuilder/index.js
@@ -10,6 +10,7 @@ SVGextend(SVG.Polygon, draw);
 const SCALE_PRESETS = [0.25, 0.5, 0.75, 1, 1.25, 1.5, 2, 3];
 const MIN_SCALE = 0.1;
 const MAX_SCALE = 3;
+const MIN_POLYGON_POINTS = 3;
 
 const ShapeBuilder = () => {
   const boardRef = useRef(null);
@@ -119,9 +120,7 @@ const ShapeBuilder = () => {
     }
 
     if (e.key === "Enter" || e.key === "Escape") {
-      poly.draw("done");
-      poly.fill("#00B39F");
-      showCytoArray();
+      closeShape();
     }
 
     if (e.ctrlKey && e.key.toLowerCase() === "z") {
@@ -195,11 +194,14 @@ const ShapeBuilder = () => {
     if (!poly) return;
 
     poly.draw("done");
-    poly.fill("#00B39F");
     const points = getPlottedPoints(poly);
-    if (points && points.length > 0) {
-      basePointsRef.current = points;
+    if (!points || points.length < MIN_POLYGON_POINTS) {
+      clearShape();
+      return;
     }
+
+    poly.fill("#00B39F");
+    basePointsRef.current = points;
     showCytoArray();
   };
 


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #169 
- Polygon creation now requires at least 3 points.
- If user tries to close with fewer than 3 points, polygon creation is automatically cancelled and reset.
- Enter and Escape now follow the same close path, so validation is consistent across keyboard and UI interactions.
- Existing valid flow for 3 or more points remains unchanged.

Fix Proof:

https://github.com/user-attachments/assets/29bebb2a-f776-4add-a70f-042254626139



**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
